### PR TITLE
Addition of 'Close' command to deal with Ghost Tickets

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -24,6 +24,7 @@ permissions:
   massivetickets.working: {description: set if you are working, default: false}
   massivetickets.teleport: {description: teleport to a player, default: false}
   massivetickets.cheat: {description: give a point 4NORaisins, default: false}
+  massivetickets.close: {description: close an offline or invalid ticket, default: false}
   massivetickets.version: {description: show plugin version, default: false}
   massivetickets.config: {description: edit MassiveTickets config, default: false}
 # -------------------------------------------- #
@@ -46,6 +47,7 @@ permissions:
       massivetickets.working: true
       massivetickets.teleport: true
       massivetickets.cheat: true
+      massivetickets.close: true
       massivetickets.version: true
       massivetickets.config: true
 # -------------------------------------------- #
@@ -59,6 +61,7 @@ permissions:
     default: false
     children:
       massivetickets.kit.rank2: true
+      massivetickets.close: true
       massivetickets.config: true
   massivetickets.kit.rank2:
     default: false

--- a/src/com/massivecraft/massivetickets/MassiveTickets.java
+++ b/src/com/massivecraft/massivetickets/MassiveTickets.java
@@ -8,6 +8,7 @@ import com.massivecraft.massivecore.util.MUtil;
 import com.massivecraft.massivecore.util.Txt;
 import com.massivecraft.massivetickets.cmd.CmdTickets;
 import com.massivecraft.massivetickets.cmd.CmdTicketsCheat;
+import com.massivecraft.massivetickets.cmd.CmdTicketsClose;
 import com.massivecraft.massivetickets.cmd.CmdTicketsCreate;
 import com.massivecraft.massivetickets.cmd.CmdTicketsDone;
 import com.massivecraft.massivetickets.cmd.CmdTicketsHighscore;
@@ -84,6 +85,7 @@ public class MassiveTickets extends MassivePlugin
 			CmdTicketsModlist.class,
 			CmdTicketsWorking.class,
 			CmdTicketsTeleport.class,
+			CmdTicketsClose.class,
 			CmdTicketsCheat.class,
 			CmdTicketsVersion.class
 		);

--- a/src/com/massivecraft/massivetickets/Perm.java
+++ b/src/com/massivecraft/massivetickets/Perm.java
@@ -14,6 +14,7 @@ public enum Perm implements Identified
 	LIST,
 	SHOW,
 	SHOW_OTHER,
+	CLOSE,
 	CREATE,
 	DONE,
 	DONE_OTHER,

--- a/src/com/massivecraft/massivetickets/cmd/CmdTickets.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTickets.java
@@ -30,6 +30,7 @@ public class CmdTickets extends MassiveTicketsCommand
 	public CmdTicketsWorking cmdTicketsWorking = new CmdTicketsWorking();
 	public CmdTicketsTeleport cmdTicketsTeleport = new CmdTicketsTeleport();
 	public CmdTicketsCheat cmdTicketsCheat = new CmdTicketsCheat();
+	public CmdTicketsClose cmdTicketsClose = new CmdTicketsClose();
 	public CmdTicketsConfig cmdMassiveTicketsConfig = new CmdTicketsConfig();
 	public CmdTicketsVersion cmdTicketsVersion = new CmdTicketsVersion();
 	
@@ -51,6 +52,7 @@ public class CmdTickets extends MassiveTicketsCommand
 		this.addChild(this.cmdTicketsWorking);
 		this.addChild(this.cmdTicketsTeleport);
 		this.addChild(this.cmdTicketsCheat);
+		this.addChild(this.cmdTicketsClose);
 		this.addChild(this.cmdMassiveTicketsConfig);
 		this.addChild(this.cmdTicketsVersion);
 		

--- a/src/com/massivecraft/massivetickets/cmd/CmdTicketsClose.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTicketsClose.java
@@ -1,0 +1,69 @@
+package com.massivecraft.massivetickets.cmd;
+
+import com.massivecraft.massivecore.MassiveException;
+import com.massivecraft.massivecore.command.requirement.RequirementHasPerm;
+import com.massivecraft.massivetickets.MassiveTickets;
+import com.massivecraft.massivetickets.Perm;
+import com.massivecraft.massivetickets.cmd.type.TypeMPlayer;
+import com.massivecraft.massivetickets.entity.MConf;
+import com.massivecraft.massivetickets.entity.MPlayer;
+
+import java.util.List;
+
+public class CmdTicketsClose extends MassiveTicketsCommand
+{
+	// -------------------------------------------- //
+	// INSTANCE
+	// -------------------------------------------- //
+	
+	private static CmdTicketsClose i = new CmdTicketsClose() { @Override public List<String> getAliases() { return MConf.get().aliasesOuterTicketsClose; } };
+	public static CmdTicketsClose get() { return i; }
+	
+	// -------------------------------------------- //
+	// CONSTRUCT
+	// -------------------------------------------- //
+	
+	public CmdTicketsClose()
+	{
+		// Parameters
+		this.addParameter(TypeMPlayer.getAny(), "player");
+		
+		// Requirements
+		this.addRequirements(RequirementHasPerm.get(Perm.CLOSE));
+	}
+	
+	// -------------------------------------------- //
+	// OVERRIDE
+	// -------------------------------------------- //
+	
+	@Override
+	public List<String> getAliases()
+	{
+		return MConf.get().aliasesInnerTicketsClose;
+	}
+	
+	@Override
+	public void perform() throws MassiveException
+	{
+		// Args
+		MPlayer ticket = this.readArg();
+		
+		// Force Sync
+		ticket.sync();
+		
+		// Is there a ticket?
+		if (!ticket.hasMessage())
+		{
+			msg("<white>%s <b>has not created a ticket.", ticket.getDisplayName(null));
+			return;
+		}
+		
+		// Apply
+		ticket.setModeratorId(null);
+		ticket.markAsDone(null);
+		
+		// Inform
+		MassiveTickets.alertModeratorsMsg("<white>%s <pink>closed <white>%s<pink>'s ticket.", msender.getDisplayName(null), ticket.getDisplayName(null));
+	}
+	
+}

--- a/src/com/massivecraft/massivetickets/entity/MConf.java
+++ b/src/com/massivecraft/massivetickets/entity/MConf.java
@@ -59,11 +59,14 @@ public class MConf extends Entity<MConf>
 	public List<String> aliasesInnerTicketsWorking = MUtil.list("working");
 	public List<String> aliasesOuterTicketsWorking = new ArrayList<>();
 	
+	public List<String> aliasesInnerTicketsTeleport = MUtil.list("tp", "teleport");
+	public List<String> aliasesOuterTicketsTeleport = new ArrayList<>();
+	
 	public List<String> aliasesInnerTicketsCheat = MUtil.list("cheat");
 	public List<String> aliasesOuterTicketsCheat = new ArrayList<>();
 	
-	public List<String> aliasesInnerTicketsTeleport = MUtil.list("tp", "teleport");
-	public List<String> aliasesOuterTicketsTeleport = new ArrayList<>();
+	public List<String> aliasesInnerTicketsClose = MUtil.list("close");
+	public List<String> aliasesOuterTicketsClose = new ArrayList<>();
 	
 	public List<String> aliasesInnerTicketsVersion = MUtil.list("version");
 	public List<String> aliasesOuterTicketsVersion = new ArrayList<>();


### PR DESCRIPTION
Command defaulted to Rank 3 permission.
Allows Invalid and/or Offline ('Ghost Tickets') to be closed, without counting towards Ticket points and highscores.

Open to other ideas or discussion - Designed more as a working patch than a long-term solution.