### PR TITLE
Revises player parameters for Commands

### DIFF
--- a/src/com/massivecraft/massivetickets/cmd/CmdTicketsCheat.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTicketsCheat.java
@@ -25,7 +25,7 @@ public class CmdTicketsCheat extends MassiveTicketsCommand
 	public CmdTicketsCheat()
 	{
 		// Parameters
-		this.addParameter(TypeMPlayer.getOnline(), "player", "you");
+		this.addParameter(TypeMPlayer.getAny(), "player", "you");
 		
 		// Requirements
 		this.addRequirements(RequirementHasPerm.get(Perm.CHEAT));

--- a/src/com/massivecraft/massivetickets/cmd/CmdTicketsDone.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTicketsDone.java
@@ -25,7 +25,7 @@ public class CmdTicketsDone extends MassiveTicketsCommand
 	public CmdTicketsDone()
 	{
 		// Parameters
-		this.addParameter(TypeMPlayer.getOnline(), "player", "you");
+		this.addParameter(TypeMPlayer.getAny(), "player", "you");
 		
 		// Requirements
 		this.addRequirements(RequirementHasPerm.get(Perm.DONE));

--- a/src/com/massivecraft/massivetickets/cmd/CmdTicketsPick.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTicketsPick.java
@@ -38,7 +38,7 @@ public class CmdTicketsPick extends MassiveTicketsCommand
 	public CmdTicketsPick()
 	{
 		// Parameters
-		this.addParameter(TypeMPlayer.getOnline(), "player");
+		this.addParameter(TypeMPlayer.getAny(), "player");
 		
 		// Requirements
 		this.addRequirements(RequirementHasPerm.get(Perm.PICK));

--- a/src/com/massivecraft/massivetickets/cmd/CmdTicketsShow.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTicketsShow.java
@@ -36,7 +36,7 @@ public class CmdTicketsShow extends MassiveTicketsCommand
 	public CmdTicketsShow()
 	{
 		// Parameters
-		this.addParameter(TypeMPlayer.getOnline(), "player", "you");
+		this.addParameter(TypeMPlayer.getAny(), "player", "you");
 		
 		// Requirements
 		this.addRequirements(RequirementHasPerm.get(Perm.SHOW));

--- a/src/com/massivecraft/massivetickets/cmd/CmdTicketsYield.java
+++ b/src/com/massivecraft/massivetickets/cmd/CmdTicketsYield.java
@@ -30,7 +30,7 @@ public class CmdTicketsYield extends MassiveTicketsCommand
 	public CmdTicketsYield()
 	{
 		// Parameters
-		this.addParameter(TypeMPlayer.getOnline(), "player");
+		this.addParameter(TypeMPlayer.getAny(), "player");
 		
 		// Requirements
 		this.addRequirements(RequirementHasPerm.get(Perm.YIELD));


### PR DESCRIPTION
Cheat, Show and Yield subcommands have been revised to allow Offline players to be targeted.
Changes to Show and Yield are applicable only to  Ghost Tickets as players should otherwise be unable to be Offline with a ticket.

Teleport is revised to allow only Online players as targets.